### PR TITLE
Init sub-projects, so their plugins are applied

### DIFF
--- a/src/leiningen/sub.clj
+++ b/src/leiningen/sub.clj
@@ -6,7 +6,8 @@
 (defn apply-task-to-subproject
   [sub-proj-dir task-name args]
   (println "Reading project from" sub-proj-dir)
-  (let [sub-project (project/read (str sub-proj-dir "/project.clj"))]
+  (let [sub-project (project/init-project
+                     (project/read (str sub-proj-dir "/project.clj")))]
     (main/apply-task task-name sub-project args)))
 
 (defn sub


### PR DESCRIPTION
Their could be a potential problem with this if the plugins provide hooks, as the hooks will not be cleared between sub-projects.

@technomancy - this is what I would like to have scoped hooks to support. Hence https://github.com/technomancy/robert-hooke/pull/10
