### PR TITLE
Added support for resolving aliases

### DIFF
--- a/src/leiningen/sub.clj
+++ b/src/leiningen/sub.clj
@@ -7,8 +7,9 @@
   [sub-proj-dir task-name args]
   (println "Reading project from" sub-proj-dir)
   (let [sub-project (project/init-project
-                     (project/read (str sub-proj-dir "/project.clj")))]
-    (main/apply-task task-name sub-project args)))
+                     (project/read (str sub-proj-dir "/project.clj")))
+        new-task-name (main/lookup-alias task-name sub-project)]
+    (main/apply-task new-task-name sub-project args)))
 
 (defn sub
   "Run task for all subprojects"


### PR DESCRIPTION
Adding support for aliases provides the ability to have one task name do different things per module.  In my case I have libraries that have "build" mapped to ["jar"] and websites that have "build" mapped to ["ring" "uberwar"].  Aliases were added with lieningen 2.
