### PR TITLE
Transitive dependency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ You can pass subproject directory locations via command line (overrides `:sub`):
 $ lein sub -s "module/foo-common:module/dep-vendor-xyz" jar
 ```
 
+You can force dependency discovery between sub-projects (overrides build order specified in the `:sub` vector):
+
+```bash
+$ lein sub clean -d
+```
+
 
 ## Getting in touch
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-sub "0.3.0"
+(defproject lein-sub "0.3.1"
   :description "Leiningen Subprojects plugin"
   :url "https://github.com/kumarshantanu/lein-sub"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/sub.clj
+++ b/src/leiningen/sub.clj
@@ -3,15 +3,47 @@
             [leiningen.core.main :as main]
             [leiningen.core.project :as project]))
 
+(defn proj-version [proj]
+  [(symbol (:group proj) (:name proj)) (:version proj)])
 
 (defn apply-task-to-subproject
-  [sub-proj-dir task-name args]
-  (println "Reading project from" sub-proj-dir)
-  (let [sub-project (project/init-project
-                     (project/read (str sub-proj-dir "/project.clj")))
-        new-task-name (main/lookup-alias task-name sub-project)]
+  [sub-project task-name args]
+  (println "Building project " (proj-version sub-project))
+  (let [new-task-name (main/lookup-alias task-name sub-project)]
     (main/apply-task new-task-name sub-project args)))
 
+(defn read-all-subprojects
+  [sub-proj-dirs]
+  (map #(project/init-project (project/read (str % "/project.clj"))) sub-proj-dirs))
+
+(defn perform-in-order [enriched-projects task-name args]
+  "Applies tasks to all projects in a recursion, unless finished or a cycle was encountered"
+  (let [ build-this-round (filter #(empty? (:internal-deps %)) enriched-projects)
+         built-this-round (into #{} (map #(proj-version %) build-this-round))
+         build-next-round (filter #(not (empty? (:internal-deps %))) enriched-projects)
+         build-next-round (map #(assoc % 
+          :internal-deps 
+          (filter
+            (fn [dep](not (contains? built-this-round dep))) 
+            (:internal-deps %))) build-next-round)]
+         (if (and (empty? build-this-round) (not (empty? build-next-round)))
+          (main/abort (str "Cycle dependecy, cannot resolve proper build order for projects: " 
+            (into #{} (map #(proj-version %) build-next-round))))
+          (if (not (empty? build-this-round))
+            (do
+              (doseq [each build-this-round]
+                (apply-task-to-subproject each task-name args))
+              (perform-in-order build-next-round task-name args))))))
+
+
+(defn enriched-projects [subprojects]
+  "Adds :internal-deps vector with all dependencies that are within this build-tree"
+  (let [all-subprojects (into #{} (map #(proj-version %) subprojects))
+        enriched-projects
+          (map (fn [project](assoc project 
+            :internal-deps 
+            (into [] (filterv #(contains? all-subprojects %) (:dependencies project))))) subprojects)]
+        enriched-projects))
 
 (defn resolve-subprojects
   "Parse `args` and return [sub-projects task-name args]"
@@ -42,10 +74,8 @@ or specify subproject dirs via command line:
 
 Note: Each sub-project directory should have its own project.clj file")))
 
-
 (defn sub
   "Run task for all subprojects"
   [project task-name & args]
   (let [[subprojects task-name args] (resolve-subprojects project task-name args)]
-    (doseq [each subprojects]
-      (apply-task-to-subproject each task-name args))))
+    (perform-in-order (enriched-projects (read-all-subprojects subprojects)) task-name args)))

--- a/subtest/child/project.clj
+++ b/subtest/child/project.clj
@@ -1,6 +1,9 @@
-(defproject child "0.1.0-SNAPSHOT"
+(def version (clojure.string/trim (:out (clojure.java.shell/sh "git" "describe" "--always"))))
+
+(defproject subtest/child version
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]])
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [subtest/common-child ~version]])

--- a/subtest/child3/.gitignore
+++ b/subtest/child3/.gitignore
@@ -1,0 +1,10 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins

--- a/subtest/child3/README.md
+++ b/subtest/child3/README.md
@@ -1,0 +1,13 @@
+# child2
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2012 FIXME
+
+Distributed under the Eclipse Public License, the same as Clojure.

--- a/subtest/child3/project.clj
+++ b/subtest/child3/project.clj
@@ -1,9 +1,9 @@
 (def version (clojure.string/trim (:out (clojure.java.shell/sh "git" "describe" "--always"))))
 
-(defproject subtest/child2 version
+(defproject subtest/child3 version
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [subtest/common-child ~version]])
+                 [subtest/child2 ~version]])

--- a/subtest/child3/src/child2/core.clj
+++ b/subtest/child3/src/child2/core.clj
@@ -1,0 +1,6 @@
+(ns child2.core)
+
+(defn foo
+  "I don't do a whole lot."
+  [x]
+  (println x "Hello, World!"))

--- a/subtest/child3/test/child2/core_test.clj
+++ b/subtest/child3/test/child2/core_test.clj
@@ -1,0 +1,7 @@
+(ns child2.core-test
+  (:use clojure.test
+        child2.core))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))

--- a/subtest/common-child/.gitignore
+++ b/subtest/common-child/.gitignore
@@ -1,0 +1,10 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins

--- a/subtest/common-child/README.md
+++ b/subtest/common-child/README.md
@@ -1,0 +1,13 @@
+# child2
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2012 FIXME
+
+Distributed under the Eclipse Public License, the same as Clojure.

--- a/subtest/common-child/project.clj
+++ b/subtest/common-child/project.clj
@@ -1,9 +1,8 @@
 (def version (clojure.string/trim (:out (clojure.java.shell/sh "git" "describe" "--always"))))
 
-(defproject subtest/child2 version
+(defproject subtest/common-child version
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [subtest/common-child ~version]])
+  :dependencies [[org.clojure/clojure "1.4.0"]])

--- a/subtest/common-child/src/child2/core.clj
+++ b/subtest/common-child/src/child2/core.clj
@@ -1,0 +1,6 @@
+(ns child2.core)
+
+(defn foo
+  "I don't do a whole lot."
+  [x]
+  (println x "Hello, World!"))

--- a/subtest/common-child/test/child2/core_test.clj
+++ b/subtest/common-child/test/child2/core_test.clj
@@ -1,0 +1,7 @@
+(ns child2.core-test
+  (:use clojure.test
+        child2.core))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))

--- a/subtest/project.clj
+++ b/subtest/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]]
-  :plugins [[lein-sub "0.3.0"]]
-  :sub ["child" "child2"])
+  :plugins [[lein-sub "0.3.1"]]
+  :sub ["common-child" "child" "child2" "child3"])


### PR DESCRIPTION
Hi Kumar,

Neat plugin — thank you!

We are using it in a rather big project with transitive dependencies, and we though it would be nice if lein-sub would've resolved them out-of-the box in a more or less automatic manner.

I've adjusted `subtest` to represent this situation.

So, dependency tree looks the following way:

```
common-child -> []
child -> [common-child]
child2 -> [common-child]
child3 -> [child2]
```

and once you run `lein sub install` in `\subtest` it will give you output like:

```
bash-3.2$ lein sub install
Building project  [subtest/common-child v0.3.0-1-g4ddbb83]
Created/lein-sub/subtest/common-child/target/provided/common-child-v0.3.0-1-g4ddbb83.jar
Wrote/lein-sub/subtest/common-child/pom.xml
Building project  [subtest/child v0.3.0-1-g4ddbb83]
Created/lein-sub/subtest/child/target/provided/child-v0.3.0-1-g4ddbb83.jar
Wrote/lein-sub/subtest/child/pom.xml
Building project  [subtest/child2 v0.3.0-1-g4ddbb83]
Created/lein-sub/subtest/child2/target/provided/child2-v0.3.0-1-g4ddbb83.jar
Wrote/lein-sub/subtest/child2/pom.xml
Building project  [subtest/child3 v0.3.0-1-g4ddbb83]
Created/lein-sub/subtest/child3/target/provided/child3-v0.3.0-1-g4ddbb83.jar
Wrote/lein-sub/subtest/child3/pom.xml
```

Might you make dependency tree as:

```
common-child -> []
child -> [common-child]
child2 -> [common-child, child2]
child3 -> [child2]
```

It will go like:

```
bash-3.2$ lein sub install
Building project  [subtest/common-child v0.3.0-1-g4ddbb83]
Created/lein-sub/subtest/common-child/target/provided/common-child-v0.3.0-1-g4ddbb83.jar
Wrote/lein-sub/subtest/common-child/pom.xml
Building project  [subtest/child v0.3.0-1-g4ddbb83]
Created/lein-sub/subtest/child/target/provided/child-v0.3.0-1-g4ddbb83.jar
Wrote/lein-sub/subtest/child/pom.xml
Cycle dependecy, cannot resolve proper build order for projects: #{[subtest/child3 "v0.3.0-1-g4ddbb83"] [subtest/child2 "v0.3.0-1-g4ddbb83"]}
```

And if you will make the dependency tree as:

```
common-child -> [child3]
child -> [common-child]
child2 -> [common-child, child2]
child3 -> [child2]
```

Output would be:

```
bash-3.2$ lein sub install
Cycle dependecy, cannot resolve proper build order for projects: #{[subtest/child "v0.3.0-1-g4ddbb83"] [subtest/child3 "v0.3.0-1-g4ddbb83"] [subtest/child2 "v0.3.0-1-g4ddbb83"] [subtest/common-child "v0.3.0-1-g4ddbb83"]}
```

---

So, as you see — it builds sub-projects in a recursion, unless finished or a cycle was encountered.
- Ilya
