### PR TITLE
New features: automatic dependency order and resumable builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 pom.xml
+.idea
+*.iml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 lein-sub will now automatically determine the optimum execution order.
 
+Sub-modules may be specified as `--submodules` or `-s`.
+Previously, only `-s` was supported.
+
+Builds are now resumable using the `--resume` (or `-r`).
 
 ## 2013-Sep-22 / 0.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes and TODO
 
+## UNRELEASED / 0.4.0
+
+lein-sub will now automatically determine the optimum execution order.
+
+
 ## 2013-Sep-22 / 0.3.0
 
 * Add `-s <subprojects>` option support (Shantanu Kumar)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Starting in 0.4.0, lein-sub will automatically determine the
 correct execution order for the sub-projects based on
 inter-project dependencies.
 
-
 Alternately, you may pass sub-project directories via the command line, using the
 `--submodules` (or `-s`) option:
 
@@ -66,6 +65,15 @@ When `--submodules` is not specified, your top-level project *must*
 have a :sub key.
 When `--submodules` *is* specified, the :sub key is ignored.
 
+## Build Continuation
+
+It can be annoying to get part way through a large build only to hit
+a minor failure in a particular module, and have to start over, even when
+it's just a matter of a tiny typo.
+
+The `--resume` (or `-r`) option instructs lein-sub to pick up where it left
+off.
+
 ## Notes
 
 lein-sub will create a file, `target/sub-cache.edn`, to store
@@ -75,6 +83,9 @@ This cache file will be recreated if deleted, or any time
 any `project.clj` file is changed.
 Even on a large project (over 40 modules), it takes less than a second
 to rebuild.
+
+It also creates a `target/sub-state.edn` file, to store what module it
+is currently building.
 
 ## Getting in touch
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # lein-sub
 
-Leiningen plugin to execute tasks on sub-projects
+Leiningen plugin to execute tasks on sub-projects.
 
 Should you need recursive behavior, consider Leiningen aliases or
 [lein-cascade](https://github.com/kumarshantanu/lein-cascade).
-
 
 ## Installation
 
@@ -12,11 +11,11 @@ Should you need recursive behavior, consider Leiningen aliases or
 
 Either install as a plugin in `~/.lein/profiles.clj`:
 
-    {:user {:plugins [[lein-sub "0.3.0"]]}}
+    {:user {:plugins [[lein-sub "0.4.0"]]}}
 
 Or, specify as a plugin in `project.clj`:
 
-    :plugins [[lein-sub "0.3.0"]]
+    :plugins [[lein-sub "0.4.0"]]
 
 ### Leiningen 1.x users
 
@@ -28,15 +27,17 @@ Or, include as a dev-dependency in `project.clj`:
 
     :dev-dependencies [[lein-sub "0.1.2"]]
 
-
 ## Usage
 
-Your project may have sub-projects (each having its own project.clj file) -
-you can specify them as follows:
+Your project may have sub-projects -
+you can specify the sub-projects as follows in the top level `project.clj`:
 
 ```clojure
 :sub ["module/foo-common" "module/dep-vendor-xyz"]
 ```
+
+These values are the _directory_ names of the sub-projects.
+Each sub-project must have its own `project.clj`.
 
 Execute the plugin:
 
@@ -47,12 +48,33 @@ $ lein sub jar      # runs "lein jar" on both
 $ lein sub install  # install both sub-project artifacts to local Maven repo
 ```
 
-You can pass subproject directory locations via command line (overrides `:sub`):
+Starting in 0.4.0, lein-sub will automatically determine the
+correct execution order for the sub-projects based on
+inter-project dependencies.
+
+
+Alternately, you may pass sub-project directories via the command line, using the
+`--submodules` (or `-s`) option:
 
 ```bash
 $ lein sub -s "module/foo-common:module/dep-vendor-xyz" jar
 ```
 
+The `:` character is used to separate the directory names.
+
+When `--submodules` is not specified, your top-level project *must*
+have a :sub key.
+When `--submodules` *is* specified, the :sub key is ignored.
+
+## Notes
+
+lein-sub will create a file, `target/sub-cache.edn`, to store
+project information between executions, including the
+execution order.
+This cache file will be recreated if deleted, or any time
+any `project.clj` file is changed.
+Even on a large project (over 40 modules), it takes less than a second
+to rebuild.
 
 ## Getting in touch
 
@@ -69,11 +91,12 @@ On Leiningen mailing list: [http://groups.google.com/group/leiningen](http://gro
 * Phil Hagelberg (https://github.com/technomancy)
 * Hugo Duncan (https://github.com/hugoduncan)
 * Creighton Kirkendall (https://github.com/ckirkendall)
+* Howard M. Lewis Ship (https://github.com/hlship)
 
 
 ## License
 
-Copyright © 2011-2013 Shantanu Kumar and contributors
+Copyright © 2011-2017 Shantanu Kumar and contributors
 
 Adapted from Phil Hagelberg's example: http://j.mp/oC9TTo
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
-(defproject lein-sub "0.3.0"
+(defproject lein-sub "0.4.0"
   :description "Leiningen Subprojects plugin"
   :url "https://github.com/kumarshantanu/lein-sub"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[com.stuartsierra/dependency "0.2.0"]]
   :eval-in-leiningen true)

--- a/src/leiningen/sub.clj
+++ b/src/leiningen/sub.clj
@@ -1,38 +1,273 @@
 (ns leiningen.sub
   (:require [clojure.string :as str]
             [leiningen.core.main :as main]
-            [leiningen.core.project :as project]))
+            [leiningen.core.project :as project]
+            [com.stuartsierra.dependency :as dep]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clojure.pprint :as pprint]
+            [clojure.tools.cli :as cli])
+  (:import (java.io PushbackReader File)))
+
+(def ^:private cache-path "target/sub-cache.edn")
+
+(defn ^:private to-message
+  [^Throwable throwable]
+  (or (.getMessage throwable)
+      (-> throwable class .getName)))
+
+;; Caching on md5 checksum, rather than DTM, would yield fewer
+;; false positives on the invalid check, but probably not worth
+;; the time & effort.
+
+(defn ^:private add-source
+  "Adds a source to the :sources key of the cached dependency structure;
+  path key and DTM value."
+  [m path]
+  (assoc-in m [:sources path] (-> path io/file .lastModified)))
+
+(defn ^:private source-is-valid?
+  [path date-time-modified]
+  (let [file (io/file path)]
+    (and (.exists file)
+         (= date-time-modified (.lastModified file)))))
+
+(defn ^:private cache-is-valid?
+  "Checks the sources to ensure that all of them exist and match the provided
+  date-time-modified."
+  [cache]
+  (->> cache
+       :sources
+       (every? (fn [[path dtm]] (source-is-valid? path dtm)))))
+
+(defn ^:private normalize-dependency
+  "Noticed that in some cases, a unqualified dependency comes out as foo/foo instead of just foo.
+  Specifically saw this with clout. Not sure why."
+  [[artifact & rest :as dependency]]
+  (let [simple-name (name artifact)]
+    (if (= (namespace artifact) simple-name)
+      (apply vector (symbol simple-name) rest)
+      dependency)))
+
+(defn ^:private build-type
+  "Categorize the build, so that we can ensure that all CLJS builds occur last.
+  Currently, when bulding a multi-project, once any project uses the lein-clsbuild
+  plugin, all subsequent projects will attempt to build using cljsbuild - and generate
+  warnings about missing :cljsbuild entry, etc."
+  [project]
+  (if (:cljsbuild project)
+    :cljs
+    :clj))
+
+(defn ^:private gen-project-db
+  "Generates the initial project database, which will ultimately be written as the cache file.
+
+  The :projects key contains a map from project name (a symbol, not the string name of the
+  sub directory) to the read (and initialized) sub-project.
+
+  The :sources key is a map from file path to file DTM, used to determine if the cached
+  data is still valid. As project files are read, the project.clj is added as a source.
+
+  sub-module-paths
+  : from the :sub key of the root project"
+  [sub-module-paths]
+  (let [start-ms (System/currentTimeMillis)
+        result (do
+                 (print "Determining project dependency ordering: ")
+                 (flush)
+                 (->>
+                   sub-module-paths
+                   ;; Should be able to do a pmap here, but then we only see
+                   ;; partial dependencies (seems like nothing from a :dependency-set
+                   ;; makes it). Leiningen is not thread safe and it's hard to
+                   ;; debug or figure out what's truly going on.
+                   (mapv (fn [dir]
+                           (let [file (str dir "/project.clj")
+                                 ;; Because of the lein-parent plugin, and use of managed dependencies,
+                                 ;; it is necessary to fully read and initialize the project, in order
+                                 ;; to determine dependencies.
+                                 project (project/read file [:base :system :provided :dev])
+                                 {proj-group-str :group
+                                  proj-name-str :name} project
+                                 project-name (symbol proj-group-str proj-name-str)]
+                             (print ".")
+                             (flush)
+                             (-> project
+                                 (select-keys [:group :name :version :root :dependencies])
+                                 (update-in [:dependencies] #(map normalize-dependency %))
+                                 (assoc :relative-dir dir
+                                        :project-name project-name
+                                        :build-type (build-type project))
+                                 (vary-meta assoc ::source file)))))
+                   (reduce (fn [m project]
+                             (let [source (-> project meta ::source)]
+                               (-> m
+                                   (add-source source)
+                                   (assoc-in [:projects (:project-name project)] project))))
+                           (add-source {} "project.clj"))))]
+    (printf " [%.2f s]%n"
+            (-> (System/currentTimeMillis)
+                (- start-ms)
+                float
+                (/ 1000.)))
+    (flush)
+    result))
+
+(defn ^:private order-projects
+  [projects]
+  (let [project-artifacts (-> projects keys set)
+        tuples (for [from-proj (vals projects)
+                     :let [from-artifact (:project-name from-proj)
+                           to-artifacts (->> from-proj
+                                             :dependencies
+                                             (map first)
+                                             (keep project-artifacts))]
+                     ;; Projects only exist in the graph if there's an edge, so always ensure
+                     ;; there's at least one edge.
+                     to-artifact (conj to-artifacts ::primordial)]
+                 [from-artifact to-artifact])
+        graph (reduce (fn [g [from to]]
+                        (dep/depend g from to))
+                      (dep/graph)
+                      tuples)]
+    (->> graph
+         dep/topo-sort
+         ;; And convert each project name back into the project data
+         ;; This is where the ::primordial is filtered out.
+         (keep projects))))
 
 
-(defn apply-task-to-subproject
+(defn ^:private create-and-cache-project-data
+  "Return project build order by performing a depth-first
+  walk of the dependency tree - returning paths from leaf to root.
+
+  cache-path
+  : path to where the cache should be written
+
+  sub-module-paths
+  : seq of strings, subfolders that contain projects to be included"
+  [sub-module-paths]
+  (let [project-db (gen-project-db sub-module-paths)
+        subs-ordered (->> project-db
+                          :projects
+                          order-projects
+                          ;; Make sure CLJS builds are last.
+                          (group-by :build-type)
+                          ((juxt :clj :cljs))
+                          (apply concat)
+                          (map :relative-dir))
+        cache-data (assoc project-db :build-order subs-ordered)]
+    (when-not (= (count sub-module-paths)
+                 (count subs-ordered))
+      (main/abort (format "%d subs after ordering, vs. %d before."
+                          (count subs-ordered)
+                          (count sub-module-paths))))
+
+    (io/make-parents cache-path)
+
+    (with-open [s (io/writer (io/file cache-path))]
+      (pprint/write cache-data :stream s))
+
+    cache-data))
+
+(defn ^:private read-cache-file
+  "Reads the project database cache, if present.
+  Checks all sources to see if they have changed.
+  If all are current, returns the cached dependency data.
+
+  Returns nil otherwise."
+  []
+  (let [^File cache-file (io/file cache-path)]
+
+    (if (not (.exists cache-file))
+      nil
+      (let [project-data
+            (try
+              (main/debug (format "Reading from `%s'." cache-path))
+
+              (with-open [reader (io/reader cache-file)
+                          pushback-reader (PushbackReader. reader)]
+                (edn/read pushback-reader))
+              (catch Throwable t
+                (main/warn (format "Unable to read from `%s': %s"
+                                   cache-file
+                                   (to-message t)))
+                nil))]
+        (cond
+
+          (nil? project-data)
+          nil
+
+          (cache-is-valid? project-data)
+          project-data)))))
+
+(defn read-project-data
+  "Gets the project data, starting from the root project.
+
+  Returns data from the cache or (failing that) does the more expensive
+  job of building the data fresh."
+  [root-project]
+  (or
+    (read-cache-file)
+    (create-and-cache-project-data (:sub root-project))))
+
+(defn ^:private apply-task-to-subproject
   [sub-proj-dir task-name args]
-  (println "Reading project from" sub-proj-dir)
+  (main/info "Reading project from" sub-proj-dir)
   (let [sub-project (project/init-project
                      (project/read (str sub-proj-dir "/project.clj")))
         new-task-name (main/lookup-alias task-name sub-project)]
     (main/apply-task new-task-name sub-project args)))
 
+(def ^:private cli-options
+  [["-s" "--submodules LIST" "Execute task in just the indicated projects (colon separated list)."]
+   ["-h" "--help" "This usage summary."]])
 
-(defn resolve-subprojects
+(defn ^:private resolve-arguments
   "Parse `args` and return [sub-projects task-name args]"
-  [project task-name args]
-  (cond
-   ;; -s "sub1:sub2" & more
-   (= "-s" task-name)
-   (if-not (> (count args) 1)
-     (main/abort "Expected: -s <subprojects> task-name [args]")
-     [(->> #"(?<!\\):"
-           (str/split (first args))
-           (map #(str/replace % #"\\:" ":"))
-           vec)
-      (second args)
-      (drop 2 args)])
-   ;; project contains :sub
-   (seq (:sub project))
-   [(:sub project) task-name args]
-   ;; otherwise error
-   :else
-   (main/abort "No subprojects defined. Define with :sub key in project.clj, e.g.
+  [project args]
+  (let [{:keys [options arguments errors summary]} (cli/parse-opts args cli-options)
+        [task-name & task-arguments] arguments
+        usage (fn [errors]
+                (println "lein sub [options] task-name [arguments]")
+                (println summary)
+
+                (when (seq errors)
+                  (println)
+                  (doseq [e errors] (println e)))
+
+                nil)]
+    (cond
+
+      (or (:help options)
+          errors)
+      (usage errors)
+
+      (nil? task-name)
+      (usage ["No task name was specified"])
+
+      ;; For explicitly named subprojects, we expect the user to supply
+      ;; valid names and execution order
+      (:subprojects options)
+      [(->> #"(?<!\\):"
+            (str/split (:subprojects options))
+            (map #(str/replace % #"\\:" ":"))
+            vec)
+       task-name
+       task-arguments]
+
+      ;; project contains :sub
+      (seq (:sub project))
+      [(-> project
+           read-project-data
+           :build-order)
+       task-name
+       task-arguments]
+
+      ;; otherwise error
+      :else
+      (do
+        (main/abort "No subprojects defined. Define with :sub key in project.clj, e.g.
 
     :sub [\"modules/dep1\" \"modules/proj-common\"]
 
@@ -40,12 +275,13 @@ or specify subproject dirs via command line:
 
     $ lein sub -s \"modules/dep1:modules/proj-common\" <task-name> [args]
 
-Note: Each sub-project directory should have its own project.clj file")))
-
+Note: Each sub-project directory should have its own project.clj file")))))
 
 (defn sub
-  "Run task for all subprojects"
-  [project task-name & args]
-  (let [[subprojects task-name args] (resolve-subprojects project task-name args)]
+  "Run task for all subprojects in dependency order"
+  {:pass-through-help true}
+  [project & args]
+  (let [[subprojects task-name args] (resolve-arguments project args)]
+    ;; subprojects will be nil if there's a parse error
     (doseq [each subprojects]
       (apply-task-to-subproject each task-name args))))

--- a/subtest/project.clj
+++ b/subtest/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]]
-  :plugins [[lein-sub "0.3.0"]]
+  :plugins [[lein-sub "0.4.0"]]
   :sub ["child" "child2"])


### PR DESCRIPTION
This patch adapts code previously implemented in-house as a hook.

It allows lein-sub to analyze the sub-projects and work out inter-dependencies and, from that, the build order.

It works around a bug in lein-cljsbuild.

It also makes build resumable; our project has 48 sub-projects, so being able to recover from minor problems and typos is very important.